### PR TITLE
Add GH action to update Mozilla store addon

### DIFF
--- a/.github/workflows/MozillaUpload.yml
+++ b/.github/workflows/MozillaUpload.yml
@@ -1,0 +1,24 @@
+name: Upload_to_store
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      
+      - name: Make package
+        run: bash scripts/firefox.sh nover
+        
+      - name: Upload xpi
+        uses: trmcnvn/firefox-addon@v1
+        with:
+          uuid: '{a9b6e295-9eef-451a-befb-696fbd8daa27}'
+          xpi: build/dist/*.xpi
+          manifest: build/FastForward.firefox/manifest.json
+          api-key: ${{ secrets.FIREFOX_API_KEY }}
+          api-secret: ${{ secrets.FIREFOX_API_SECRET }}


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: People (rightfully) complaining on discord

### A brief description of what you did
Added a workflow to build an xpi and upload it using Trmcnvn's firefox-addon action

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [N/A] Tested on Chromium- Browser OS
- [N/A] Tested on Firefox

\* indicates required
