### PR TITLE
Add incognito key in chromium manifest

### DIFF
--- a/platform_spec/chromium/manifest.json
+++ b/platform_spec/chromium/manifest.json
@@ -13,6 +13,7 @@
 	"homepage_url": "https://fastforward.team",
 	"version": "13.15.2",
 	"author": "FastForward Team",
+	"incognito": "split",
 	"permissions": [
 		"alarms",
 		"storage",


### PR DESCRIPTION
Fixes bypassing incognito mode in chrome.

<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: Chromium extension not working in incognito mode

<!-- A breif description of what you did -->
https://developer.chrome.com/docs/exensions/mv3/manifest/incognito/

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Chrome OpenSUSE
- [N/A] Tested on Firefox

\* indicates required
