### PR TITLE
Add XImageSharing bypass

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2325,6 +2325,16 @@ ensureDomLoaded(()=>{
 	})
 	domainBypass("techynroll.com", ()=>awaitElement("a#enablebtn", a=>safelyAssign(a.href)))
 	hrefBypass(/meostream\.com\/links\//,()=> ifElement("a#link",safelyNavigate))
+	//XImageSharing
+	ifElement('input[type=submit][value="Continue to image..."]', submit => {
+	    submit.click()
+	})
+	ifElement('span.roll ~ img.pic', img => {
+		// zoom image
+		img.removeAttribute("style")
+		// remove zoom icon
+		img.parentElement.getElementsByClassName("roll")[0].remove()
+	})
 
 	//Insertion point for bypasses detecting certain DOM elements. Bypasses here will no longer need to call ensureDomLoaded.
 	let t=document.querySelector("title")

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2327,7 +2327,7 @@ ensureDomLoaded(()=>{
 	hrefBypass(/meostream\.com\/links\//,()=> ifElement("a#link",safelyNavigate))
 	//XImageSharing
 	ifElement('input[type=submit][value="Continue to image..."]', submit => {
-	    submit.click()
+		submit.click()
 	})
 	ifElement('span.roll ~ img.pic', img => {
 		// zoom image


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>

Adds a bypass for websites "Powered by [XImageSharing](https://sibsoft.net/ximagesharing.html)" (e.g. imgsto.com, picbaron.com, and many more)

- [x] I made sure there are no unnecessary changes in the code*
- [ ] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
