### PR TITLE
Update pixiv rules

### DIFF
--- a/src/js/rules.json
+++ b/src/js/rules.json
@@ -24,7 +24,8 @@
 	"query_raw": [
 		"*://*.anonym.to/?*",
 		"*://*.anonymz.com/?*",
-		"*://*.hidereferrer.com/?*"
+		"*://*.hidereferrer.com/?*",
+		"*://*.pixiv.net/jump.php?*"
 	],
 	"query_base64": [
 		"*://*.hikarinoakariost.info/out/?*",
@@ -62,7 +63,6 @@
 		"*://*.itsbx.com/redirect/?url=*",
 		"*://*.forocoches.com/link.php?url=*",
 		"*://*.pixiv.net/jump.php?url=*",
-		"*://*.pixiv.net/jump.php?*",
 		"*://hdblurayindir.com/git.php?url=*",
 		"*://gate.sc/?url=*",
 		"*://freetutsdownload.net/redirect-to/?url=*",

--- a/src/js/rules.json
+++ b/src/js/rules.json
@@ -62,6 +62,7 @@
 		"*://*.itsbx.com/redirect/?url=*",
 		"*://*.forocoches.com/link.php?url=*",
 		"*://*.pixiv.net/jump.php?url=*",
+		"*://*.pixiv.net/jump.php?*",
 		"*://hdblurayindir.com/git.php?url=*",
 		"*://gate.sc/?url=*",
 		"*://freetutsdownload.net/redirect-to/?url=*",


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


<!-- A breif description of what you did -->
Pixiv has 2 different redirects:

1) via `jump.php?url=<encoded_target_url>`
2) via `jump.php?<encoded_target_url>`

The first one appears on links from profiles (eg: Twitter link on [this profile](https://www.pixiv.net/en/users/2188232)). The second one is used for links in posts (eg: [some post](https://www.pixiv.net/en/artworks/93045020)). This PR adds the second variant to the rule set.

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [ ] Tested on Chromium- Browser OS
- [ ] Tested on Firefox

\* indicates required
