### PR TITLE
Fix tei.ai for certain target domains

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -460,7 +460,7 @@ domainBypass(/bc\.vc|bcvc\.live/,()=>{
 })
 domainBypass("tei.ai", () => {
 	ensureDomLoaded(() => {
-	    var link = atob("aH" + document.querySelector("#link-view [name='token']").value.split("aH")[1]);
+	    var link = atob(document.querySelector("#link-view [name='token']").value).match(/https?:\/\/.*/i);
 	    safelyNavigate(link);
 	});
 });


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: https://github.com/FastForwardTeam/FastForward/issues/179

Some target-domains base64 contained "aH" in the actual domain which resulted in an incomplete spitted link.
New code will grab any valid link (starting with http/s) after base64-decode and use that.

- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
