### PR TITLE
Updated Bypass for ouoio

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -979,7 +979,7 @@ ensureDomLoaded(()=>{
 				ifElement("form#form-captcha", form => {
 						form.action = `/xreallcygo${location.pathname}`
 						form.submit()
-				},() => crowdBypass())					
+				},() => crowdBypass())
 			}
 		}
 	})

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -960,7 +960,7 @@ ensureDomLoaded(()=>{
 		document.cookie="referrer=1"
 		xhr.send()
 	})
-	domainBypass(/ouo\.(io|press)|lnk2\.cc/,()=>{
+	domainBypass(/lnk2\.cc/,()=>{
 		if(location.pathname.substr(0,4)=="/go/")
 		{
 			document.querySelector("form").submit()
@@ -968,6 +968,19 @@ ensureDomLoaded(()=>{
 		else
 		{
 			crowdBypass()
+		}
+	})
+	domainBypass(/ouo\.(press|io)/, () => {
+		if(location.pathname !== '/'){
+			if(/(go|fbc)/.test(location.pathname.split("/")[1])){
+				document.querySelector("form").submit()
+			}
+			else {
+				ifElement("form#form-captcha", form => {
+						form.action = `/xreallcygo${location.pathname}`
+						form.submit()
+				},() => crowdBypass())					
+			}
 		}
 	})
 	domainBypass("drivehub.link",()=>ifElement("a#proceed[href]",safelyNavigate))


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interests in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>

<!-- A brief description of what you did -->
Example Links (The destination is https://fastforward.team/)
https://ouo.press/vsCQk7
https://ouo.press/fbc/vsCQk7
https://ouo.io/vsCQk7
https://ouo.io/fbc/vsCQk7

I have updated the bypass method, added a few edge cases and hopefully, we might not have to use crowd-bypass anytime soon.

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [ ] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
