### PR TITLE
Add bypass for za.gl

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -983,6 +983,39 @@ ensureDomLoaded(()=>{
 			}
 		}
 	})
+  domainBypass(/za\.(gl|uy)/, () => {
+		ifElement("form#link-view", form => {
+		  document.querySelector('#x').value = '192'
+			document.querySelector('#y').value = '114'
+			document.querySelector('input[name="givenX"]').value = 'VFl0utOEF6a7BiS8YJdqTg=='
+			document.querySelector('input[name="givenY"]').value = 'rsW06vBB1oIFVpnFz61t5Q=='
+			form.submit()
+			return
+		})
+
+		ifElement("form#go-link", () => {
+			window.setTimeout(() => {
+				let payload = new URLSearchParams(new FormData(document.querySelector("#go-link"))).toString();
+					fetch(`${location.origin}/links/go`, {
+						"headers": {
+              "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+              "x-requested-with": "XMLHttpRequest"
+						},
+						"body":payload,
+						"method": "POST",
+						"mode": "cors",
+					})
+					.then(res => res.json())
+					.then(res => {
+						if(res.status !== "error"){
+						  safelyNavigate(res.url)
+							return
+						}
+						crowdBypass()
+					})
+				}, 3500)
+		}, () => crowdBypass())
+	})
 	domainBypass("drivehub.link",()=>ifElement("a#proceed[href]",safelyNavigate))
 	domainBypass("oxy.st",()=>{awaitElement("a.btn.btn-primary.btn-lg",t=>{safelyAssign(t.href)}),ifElement("button#download[disabled]",t=>{awaitElement("button#download:not([disabled])",t=>{t.click()})})})
 	domainBypass("oxy.cloud",()=>{ifElement("button#download[disabled]",d=>{awaitElement("button#download:not([disabled])",d=>{d.click()})})})

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -983,9 +983,9 @@ ensureDomLoaded(()=>{
 			}
 		}
 	})
-  domainBypass(/za\.(gl|uy)/, () => {
+	domainBypass(/za\.(gl|uy)/, () => {
 		ifElement("form#link-view", form => {
-		  document.querySelector('#x').value = '192'
+			document.querySelector('#x').value = '192'
 			document.querySelector('#y').value = '114'
 			document.querySelector('input[name="givenX"]').value = 'VFl0utOEF6a7BiS8YJdqTg=='
 			document.querySelector('input[name="givenY"]').value = 'rsW06vBB1oIFVpnFz61t5Q=='
@@ -998,8 +998,8 @@ ensureDomLoaded(()=>{
 				let payload = new URLSearchParams(new FormData(document.querySelector("#go-link"))).toString();
 					fetch(`${location.origin}/links/go`, {
 						"headers": {
-              "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-              "x-requested-with": "XMLHttpRequest"
+							"content-type":"application/x-www-form-urlencoded; charset=UTF-8",
+							"x-requested-with":"XMLHttpRequest"
 						},
 						"body":payload,
 						"method": "POST",
@@ -1008,7 +1008,7 @@ ensureDomLoaded(()=>{
 					.then(res => res.json())
 					.then(res => {
 						if(res.status !== "error"){
-						  safelyNavigate(res.url)
+							safelyNavigate(res.url)
 							return
 						}
 						crowdBypass()


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interests in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: #94
Fixes: #53 

<!-- A brief description of what you did -->
Just as the commit says it bypasses Za.gl. This domain has 2 pages.

1. It asks you to solve a custom captcha where you have to click on a green dot and based on the position of the x and y coordinates of your mouse pointer the captcha Is verified.
2. The second page that comes after the captcha asks you to view a total of Three 5 second Ads i.e a total of 15 seconds.

This method can bypass the 1st page as well as the 2nd page but the thing is on the 2nd page there is a server-side check so you have to wait for 3-4 seconds before the actual URL can be fetched from the server.

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Chrome Windows
- [x] Tested on Firefox

\* indicates required
