### PR TITLE
Implement ffclipboard

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -51,6 +51,17 @@ brws.runtime.onInstalled.addListener(details=>{
 	{
 		brws.tabs.create({url:"https://fastforward.team/firstrun"})
 	}
+	//init clipboard
+	chrome.storage.local.get({ff_clipboard: "{}"}, function(data) {
+		chrome.storage.local.set({ff_clipboard: data.ff_clipboard}, function() {
+	})})
+})
+
+//clean clipboard on startup
+brws.runtime.onStartup.addListener(() => {
+	chrome.storage.local.get({ff_clipboard: "{}"}, function(data) {
+		chrome.storage.local.set({ff_clipboard: data.ff_clipboard}, function() {
+	})})
 })
 
 // Uninstall handler

--- a/src/js/content_script.js
+++ b/src/js/content_script.js
@@ -129,7 +129,9 @@ if(document instanceof Document)
 		});
 		brws.storage.local.get('ff_clipboard', function(result) {
 			ffClipboard_stored = result.ff_clipboard
-			ffClipboard_stored = encodeURIComponent(ffClipboard_stored)
+
+			//encodeURIcomponent and replace whatever's not encoded, https://stackoverflow.com/a/16435373/17117909
+			ffClipboard_stored = encodeURIComponent(ffClipboard_stored).replace(/\-/g, "%2D").replace(/\_/g, "%5F").replace(/\./g, "%2E").replace(/\!/g, "%21").replace(/\~/g, "%7E").replace(/\*/g, "%2A").replace(/\'/g, "%27").replace(/\(/g, "%28").replace(/\)/g, "%29")
 			let script=document.createElement("script")
 			script.innerHTML=`(()=>{
 				const crowdEnabled=`+(res.crowdEnabled?"true":"false")+`,

--- a/src/js/content_script.js
+++ b/src/js/content_script.js
@@ -1,5 +1,5 @@
 //If you want to add your own bypass, go to injection_script.js
-if(document instanceof HTMLDocument)
+if(document instanceof Document)
 {
 	let clipboardIndex=location.hash.indexOf("#bypassClipboard="),ignoreCrowdBypass=false,bypassClipboard=""
 	if(location.hash.substr(-18)=="#ignoreCrowdBypass")
@@ -117,19 +117,34 @@ if(document instanceof HTMLDocument)
 		crowdPath=location.pathname.substr(1),
 		referer=location.href
 
-		let script=document.createElement("script")
-		script.innerHTML=`(()=>{
-			const crowdEnabled=`+(res.crowdEnabled?"true":"false")+`,
-			ignoreCrowdBypass=`+(ignoreCrowdBypass?"true":"false")+`,
-			bypassClipboard="`+bypassClipboard.split("\\").join("\\\\").split("\"").join("\\\"")+`"
-			if(location.href=="https://universal-bypass.org/firstrun")
-			{
-				location.replace("https://universal-bypass.org/firstrun?1")
-				return
+		//ffclipboard reciever
+		window.addEventListener("message", function(event) {
+			// We only accept messages from ourselves
+			if (event.source != window) {
+				return;
 			}
-			`+res.injectionScript+`
-		})()`
-		script=document.documentElement.appendChild(script)
-		setTimeout(()=>document.documentElement.removeChild(script),10)
+			if (event.data.type === "ffclipboardSet") {
+				brws.storage.local.set({ff_clipboard: event.data.text})
+			}
+		});
+		brws.storage.local.get('ff_clipboard', function(result) {
+			ffClipboard_stored = result.ff_clipboard
+			ffClipboard_stored = encodeURIComponent(ffClipboard_stored)
+			let script=document.createElement("script")
+			script.innerHTML=`(()=>{
+				const crowdEnabled=`+(res.crowdEnabled?"true":"false")+`,
+				ignoreCrowdBypass=`+(ignoreCrowdBypass?"true":"false")+`,
+				bypassClipboard="`+bypassClipboard.split("\\").join("\\\\").split("\"").join("\\\"")+`"
+				let ffClipboard_stored="`+ffClipboard_stored+`"
+				if(location.href=="https://universal-bypass.org/firstrun")
+				{
+					location.replace("https://universal-bypass.org/firstrun?1")
+					return
+				}
+				`+res.injectionScript+`
+			})()`
+			script=document.documentElement.appendChild(script)
+			setTimeout(()=>document.documentElement.removeChild(script),10)
+	});
 	})
 }

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -285,10 +285,19 @@ backgroundScriptBypassClipboard=c=>{
 persistHash=h=>ensureDomLoaded(()=>{
 	document.querySelectorAll("form[action]").forEach(e=>e.action+="#"+h)
 	document.querySelectorAll("a[href]").forEach(e=>e.href+="#"+h)
-})
+}),
+//decodes https://stackoverflow.com/a/16435373/17117909
+decodeURIEncodedMod=(s)=>{
+    try{
+        return decodeURIComponent(s.replace(/\%2D/g, "-").replace(/\%5F/g, "_").replace(/\%2E/g, ".").replace(/\%21/g, "!").replace(/\%7E/g, "~").replace(/\%2A/g, "*").replace(/\%27/g, "'").replace(/\%28/g, "(").replace(/\%29/g, ")"));
+    }catch (e) {
+		return null
+    }
+}
+
 
 const ffClipboard = function() {}
-ffClipboard_stored = decodeURIComponent(ffClipboard_stored) //ffClipboard_stored is defined in content_script.js
+ffClipboard_stored = decodeURIEncodedMod(ffClipboard_stored) //ffClipboard_stored is defined in content_script.js
 //returns an ffclipboard entry, if id does not exist, returns null
 ffClipboard.get =(id) => {
 	try {

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -286,6 +286,58 @@ persistHash=h=>ensureDomLoaded(()=>{
 	document.querySelectorAll("form[action]").forEach(e=>e.action+="#"+h)
 	document.querySelectorAll("a[href]").forEach(e=>e.href+="#"+h)
 })
+
+const ffClipboard = function() {}
+ffClipboard_stored = decodeURIComponent(ffClipboard_stored) //ffClipboard_stored is defined in content_script.js
+//returns an ffclipboard entry, if id does not exist, returns null
+ffClipboard.get =(id) => {
+	try {
+		var ffClipboardObj = JSON.parse(ffClipboard_stored) 
+	} catch(e) {
+		return e
+	}
+	if (ffClipboardObj === null) {
+		ffClipboardObj = {}
+	}
+	if (!(id in ffClipboardObj)) {
+		return null
+	}
+	return ffClipboardObj[id]
+}
+//sets ffclipboard contents, if id does not exist, creates it
+ffClipboard.set =(id, value) => {
+	try {
+		var ffClipboardObj = JSON.parse(ffClipboard_stored)
+	} catch(e) {
+		return e
+	}
+		
+	if (ffClipboardObj === null) {
+		ffClipboardObj = {}
+	}
+	ffClipboardObj[id] = value
+	let message = { type: "ffclipboardSet", text: JSON.stringify(ffClipboardObj) }
+	window.postMessage(message, "*") //send message to content script
+}
+//deletes ffclipboard contents and frees up storage , if id does not exist, does nothing
+ffClipboard.free =(id) => {
+	try {
+		var ffClipboardObj = JSON.parse(ffClipboard_stored)
+	} catch(e) {
+		return e
+	}
+		
+	if (ffClipboardObj === null) {
+		ffClipboardObj = {}
+	}
+	if (!(id in ffClipboardObj)) {
+		return
+	}
+	delete ffClipboardObj[id]
+	let message = { type: "ffclipboardSet", text: JSON.stringify(ffClipboardObj) }
+	window.postMessage(message, "*")
+}
+
 let navigated=false,
 bypassed=false,
 domain=location.hostname,


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>

**ℹThis PR makes changes to files which aren't auto-updated. Builds will have to be manually submitted to browser stores after merging.**

Fix*e*s: https://github.com/FastForwardTeam/FastForward/issues/40#issuecomment-994383307

New API for making bypasses that need cross-domain temporary storage, basically variables that you can use on multiple sites

```js
ffClipboard.set(ID, value)

a = ffClipboard.get(ID)
console.log(a)						// value

ffClipboard.free(ID)
a = ffClipboard.get(ID)
console.log(a)						//null
```

`ffClipboard.get(ID)` returns an ffclipboard entry, if id does not exist, returns null
`ffClipboard.set(ID, value)` sets an ffclipboard entry, if id does not exist, creates it
`ffClipboard.free(ID)` deletes an ffclipboard entry and frees up storage†, if id does not exist, does nothing

†[Chrome limits storage to 5mb](https://developer.chrome.com/docs/extensions/reference/storage/#property-sync-sync-QUOTA_BYTES)

<!-- A breif description of what you did -->

<!--Add an x to mark as done-->
- [?] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Chrome Windows
- [ ] Tested on Firefox

\* indicates required
