### PR TITLE
Remove Fluxus, ksapi, and Oxygen U bypass and change krnl.gg to krnl.ca

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -56,11 +56,7 @@ unsafelyNavigate=target=>{
 	let url="https://universal-bypass.org/bypassed?target="+encodeURIComponent(target)+"&referer="+encodeURIComponent(referer)
 	switch(target)//All values here have been tested using "Take me to destinations after 0 seconds."
 	{
-		case (/fluxteam|ksapi|oxygenu\.xyz/.exec(target)||{}).input:
-		url+="&safe_in=85"
-		break;
-
-		case (/krnl\.gg/.exec(target)||{}).input:
+		case (/krnl\.ca/.exec(target)||{}).input:
 		url+="&safe_in=15"
 		break;
 	}


### PR DESCRIPTION
Fluxus, ksapi, and Oxygen U bypass is no longer needed

<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: Link to issue

<!-- A breif description of what you did -->

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
