### PR TITLE
Update injection_script.js

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -1889,7 +1889,20 @@ ensureDomLoaded(()=>{
 	domainBypass("work.ink", () => {
 		ifElement("#redirect-button", () => openFinalLink())
 	})
+	
 	//Insertion point for domain-or-href-specific bypasses running after the DOM is loaded. Bypasses here will no longer need to call ensureDomLoaded.
+	
+	domainBypass("forexmab.com", () => {
+    		ifElement("#molien", a => {safelyNavigate(a.firstElementChild.href)})})
+		
+	domainBypass("forex-articles.com",()=>ifElement("#FilterSearch",f=>{
+		f.target="_self"
+		f.submit()}))
+    		
+	domainBypass("forexlap.com",()=>ifElement("#molien", a=>{
+    		let b=a.getElementsByTagName("form")
+    		b[0].submit()}))
+
 	hrefBypass(/https:\/\/fmoviesdl.com\/links\//, () => {
 		ifElement("#link", a => {
 		    safelyNavigate(a.href)

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -1893,15 +1893,18 @@ ensureDomLoaded(()=>{
 	//Insertion point for domain-or-href-specific bypasses running after the DOM is loaded. Bypasses here will no longer need to call ensureDomLoaded.
 	
 	domainBypass("forexmab.com", () => {
-    		ifElement("#molien", a => {safelyNavigate(a.firstElementChild.href)})})
+    		ifElement("#molien", a => {safelyNavigate(a.firstElementChild.href)})
+	})
 		
 	domainBypass("forex-articles.com",()=>ifElement("#FilterSearch",f=>{
 		f.target="_self"
-		f.submit()}))
+		f.submit()
+	}))
     		
 	domainBypass("forexlap.com",()=>ifElement("#molien", a=>{
     		let b=a.getElementsByTagName("form")
-    		b[0].submit()}))
+    		b[0].submit()
+	}))
 
 	hrefBypass(/https:\/\/fmoviesdl.com\/links\//, () => {
 		ifElement("#link", a => {


### PR DESCRIPTION
Bypasses for some sites requiring several "next" clicks like forexmab.com, forexlap.com, forex-articles.com.
Tested and working fine.

<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: Link to issue

<!-- A brief description of what you did -->
Added 3 bypasses to sites which require one to click a link at the top of page to send us to bottom and click another NEXT link. These 3 sites are often chained together.
Example: http://linkjust.com/ackNeTSd

<!--Add an x to mark as done-->
- [X] I made sure there are no unnecessary changes in the code*
- [X] Tested on Chromium- Browser OS
- [ ] Tested on Firefox

\* indicates required
