### PR TITLE
Bypass PaperMC Legacy quiz

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -1918,6 +1918,12 @@ ensureDomLoaded(()=>{
 		    })
 		})
 	})
+	domainBypass("papermc.io", () => {
+		if (location.pathname.includes("legacy")) {
+			document.getElementById("quiz").style.display = 'none';
+			document.getElementById("content").style.display = 'block';
+		}
+	})
 	domainBypass("egao.in", () => {
       ifElement("#SafelinkChecker", button => {
           fetch("https://egao.in/safelink", {


### PR DESCRIPTION
PaperMC asks you to fill out a quiz, that confirms that you know that you won't receive any support for legacy builds.
It's annoying, and it doesn't even save it when you fill it out. You have to fill it in every time you visit the legacy downloads site.

<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: Link to issue

<!-- A breif description of what you did -->

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Chrome Windows
- [x] Tested on Firefox

\* indicates required

<details> <summary>Changes by maintainers</summary>
- Added chromium test - @NotAProton 
</details>
