### PR TITLE
Fix typo in pull request template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ present and future rights to this software under copyright law.
 
 Fixes: Link to issue
 
-<!-- A breif description of what you did -->
+<!-- A brief description of what you did -->
 
 <!--Add an x to mark as done-->
 - [ ] I made sure there are no unnecessary changes in the code*


### PR DESCRIPTION
Fix typo in pull request template.

<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: Link to issue

<!-- A breif description of what you did -->

<!--Add an x to mark as done-->
- [ ] I made sure there are no unnecessary changes in the code*
- [ ] Tested on Chromium- Browser OS
- [ ] Tested on Firefox

\* indicates required
