### PR TITLE
fix mirrored.to/files, not sure about the down/getlink

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -1288,8 +1288,6 @@ ensureDomLoaded(()=>{
 			f.action+="#bypassClipboard="+location.pathname.substr(1)
 		})
 	}))
-	hrefBypass(/mirrored\.to\/files\//,()=>ifElement("#dl_form button",b=>b.click()))
-	hrefBypass(/mirrored\.to\/(down|get)link\//,()=>ifElement(".centered.highlight a[href]",safelyNavigate))
 	hrefBypass(/new\.lewd\.ninja\/external\/game\/([0-9]+)\/([a-z0-9]{64})/,m=>{
 		let f=document.createElement("form")
 		f.method="POST"
@@ -2618,6 +2616,13 @@ domainBypass('apkadmin.com', () => {
     c.innerHTML = ''
   })
 })
+
+	hrefBypass(/mirrored\.to\/files\//,()=> {
+		if (location.href.includes('hash')) return; // we already bypassed to here
+		const href = document.querySelector(`a[href^="${location.href}"]`).href;
+		safelyAssign(href);
+	})
+	hrefBypass(/mirrored\.to\/(down|get)link\//,()=>ifElement(".centered.highlight a[href]",safelyNavigate))
 
 
 


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: [Link to issue](https://github.com/FastForwardTeam/FastForward/issues/441)

<!-- A brief description of what you did -->

they potentially changed the design a tiny bit, now just checking for a link that starts with the url since the button press just adds the correct hash to it.

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [ ] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
