### PR TITLE
simple quick and dirty bypass overruling

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -1,7 +1,20 @@
   /////////////////////////////////////////////////////////////////////////////////////////////
  // If you want to add your own bypass, add it above the relevant "Insertion point" comment //
 /////////////////////////////////////////////////////////////////////////////////////////////
+const bypass_definitions = new Map();
+class FastForwardBypassDefinition  {
+	constructor({url, is_regex, execution}) {
+		this.url = url;
+		this.is_regex = is_regex;
+		this.execution = execution;
+	}
 
+	update({url, is_regex, execution}) {
+		this.url = url;
+		this.is_regex = is_regex;
+		this.execution = execution;
+	}
+}
 //Variables
 let isGoodLink_allowSelf=false
 //Copying important functions to avoid interference from other extensions or the page
@@ -116,28 +129,29 @@ keepLooking=f=>{
 	}
 }
 domainBypass=(domain,f)=>{
-	if(bypassed)
-	{
-		return
+	let FastForward_definition = new FastForwardBypassDefinition({url: domain, is_regex: typeof domain !== 'string' && 'test' in domain, execution: f});
+	if (bypass_definitions.has(domain.toString())) {
+		FastForward_definition = bypass_definitions.get(domain.toString());
 	}
+	FastForward_definition.update({url: domain, is_regex: typeof domain !== 'string' && 'test' in domain, execution: f});
+	bypass_definitions.set(domain.toString(), FastForward_definition);
+
 	if(typeof f!="function")
 	{
 		alert("FastForward: Bypass for "+domain+" is not a function")
 	}
 	if(typeof domain=="string")
 	{
-		if(location.hostname==domain||location.hostname.substr(location.hostname.length-(domain.length+1))=="."+domain)
+		if(location.hostname === domain || location.hostname.substr(location.hostname.length-(domain.length+1)) === "." + domain)
 		{
-			bypassed=true
-			f()
+			FastForward_definition.execution();
 		}
 	}
 	else if("test" in domain)
 	{
 		if(domain.test(location.hostname))
 		{
-			bypassed=true
-			f()
+			FastForward_definition.execution();
 		}
 	}
 	else
@@ -2654,7 +2668,7 @@ domainBypass("acorta-link.com", () => {
             if (!/^(?:f|ht)tps?\:\/\//.test(url)) {
                 url = "http:" + url;
             }
-            safelyNavigate(url) 
+            safelyNavigate(url)
         }
     })
 })

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2,6 +2,7 @@
  // If you want to add your own bypass, add it above the relevant "Insertion point" comment //
 /////////////////////////////////////////////////////////////////////////////////////////////
 const bypass_definitions = new Map();
+const href_bypasses = new Map();
 class FastForwardBypassDefinition  {
 	constructor({url, is_regex, execution}) {
 		this.url = url;
@@ -160,6 +161,12 @@ domainBypass=(domain,f)=>{
 	}
 },
 hrefBypass=(regex,f)=>{
+	let FastForward_definition = new FastForwardBypassDefinition({url: domain, is_regex: true, execution: f});
+	if (href_bypasses.has(domain.toString())) {
+		FastForward_definition = href_bypasses.get(domain.toString());
+	}
+	FastForward_definition.update({url: domain, is_regex: true, execution: f});
+	href_bypasses.set(domain.toString(), FastForward_definition);
 	if(bypassed)
 	{
 		return
@@ -172,7 +179,7 @@ hrefBypass=(regex,f)=>{
 	if(res)
 	{
 		bypassed=true
-		f(res)
+		FastForward_definition.execution(res)
 	}
 },
 ensureDomLoaded=(f,if_not_bypassed)=>{


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: no issue
<!-- A brief description of what you did -->

we now overrule the set domainbypasses from the options, this way developers can use the options instead of having to rebuild with the new changes, or remove from the online set injection_script.js

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
