### PR TITLE
Add gaminplay.com bypass

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -1700,6 +1700,16 @@ ensureDomLoaded(()=>{
 			safelyNavigate(safelink)
 		}
 	}))
+	domainBypass("gaminplay.com",()=>{
+		const regex=/var YuideaLink = '(.+)';/
+		document.querySelectorAll("script").forEach(script=>{
+			let matches=regex.exec(script.textContent)
+			if(matches&&matches[1])
+			{
+				safelyNavigate(matches[1])
+			}
+		})
+	})
 	domainBypass("dl.helow.id",()=>ifElement("button#btn6",b=>b.onclick()))
 	domainBypass("dl.ocanoke.com",()=>{
 		crowdPath(location.pathname.split("/").pop())


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: [#297](https://github.com/FastForwardTeam/FastForward/issues/297) (Example link in issue is broken/expired)

<!-- A brief description of what you did -->
Added explicit gaminplay.com bypass.
Site uses safelink_redirect bait which previously caused FastForward to redirect to empty go.adslinkfly.online (or others?) page.
User has to solve a required captcha and then script will pick up the link which bypasses 10 second waiting time.

<!--Add an x to mark as done-->
- [X] I made sure there are no unnecessary changes in the code*
- [X] Tested on Chrome
- [X] Tested on Firefox

\* indicates required
