### PR TITLE
Add forex/fx4vip bypass (linkjust)

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -1489,7 +1489,21 @@ ensureDomLoaded(()=>{
 		x=x.substring(4,x.length-kp)
 		safelyAssign(isSSL?"https://"+x:"http://"+x)
 	}))
-	domainBypass(/(kora4top|forexlap)\.com/,()=>ifElement("div#m1x2 a",safelyNavigate))
+	domainBypass(/(kora4top)\.com/,()=>ifElement("div#m1x2 a",safelyNavigate))
+	domainBypass(/(forexlap|forex-articles|forexmab)\.com/, () => {
+		ensureDomLoaded(() => {
+		ifElement("center.oto>a", a => { 
+			a.click() })
+		})
+	})
+	domainBypass("fx4vip.com", () => {
+		ensureDomLoaded(() => {
+		ifElement("#button1", a => {
+			a.removeAttribute("disabled");
+			a.click();
+		})
+		})
+	})
 	domainBypass("soft8ware.com",()=>{
 		if(typeof count=="number"&&typeof countdown=="function")
 		{


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: #315 

<!-- A brief description of what you did -->
I added a bypass to several forex sites which are used by link shortener "linkjust". Here is an example link which redirects to "google.com" : https://linkjust.com/testfastigg
I removed the old "forexlap bypass" because its outdated and does nothing. I dont know about "kora4top" so I didnt remove it to not make any unnecessary code changes.


<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
