### PR TITLE
make the notifcations stackable

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -299,15 +299,30 @@ contributeAndNavigate=target=>{
 	}
 },
 insertInfoBox=text=>ensureDomLoaded(()=>{
-	const div=document.createElement("div")
-	div.style='z-index:999999;position:fixed;bottom:20px;right:20px;margin-left:20px;background:#eee;border-radius:10px;padding:20px;color:#111;font-size:21px;box-shadow:#111 0px 5px 40px;max-width:500px;font-family:-apple-system,BlinkMacSystemFont,segoe ui,Roboto,helvetica neue,Arial,sans-serif,apple color emoji,segoe ui emoji,segoe ui symbol;line-height:normal;cursor:pointer'
+	// ffibv1 = FastForwardInfoBoxVersion1
+	let infobox_container = document.querySelector('div#ffibv1');
+
+	if (!infobox_container) {
+		infobox_container = document.createElement('div');
+		infobox_container.setAttribute('id', 'ffibv1');
+		infobox_container.setAttribute('style', `
+			z-index: 99999999; position: fixed; bottom: 0; line-height:normal;
+			right: 0; padding: 20px; color:#111; font-size:21px;
+			font-family:-apple-system,BlinkMacSystemFont,segoe ui,Roboto,helvetica neue,Arial,sans-serif,apple color emoji,segoe ui emoji,segoe ui symbol;
+			max-width:500px; display: flex; flex-direction: column-reverse;
+		`);
+
+		document.body.appendChild(infobox_container);
+	}
+	const div=document.createElement("div");
+	div.style='margin-left:20px; margin-bottom: 20px;background:#eee;border-radius:10px;padding:20px;box-shadow:#111 0px 5px 40px;cursor:pointer'
 	div.innerHTML='<img src="{{icon/48.png}}" style="width:24px;height:24px;margin-right:8px"><span style="display:inline"></span>'
 	div.setAttribute("tabindex","-1")
 	div.setAttribute("aria-hidden","true")
 	const span=div.querySelector("span")
 	span.textContent=text
 	div.onclick=()=>document.body.removeChild(div)
-	document.body.appendChild(div)
+	infobox_container.appendChild(div)
 }),
 backgroundScriptBypassClipboard=c=>{
 	if(c)


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: there is no issue related

<!-- A brief description of what you did -->
currently there is no option for stacking infoboxes, this caused confusion with linkvertise as example, there would only show 1 info box and that could be either about solving the captcha OR about not being allowed to bypass.

![image](https://user-images.githubusercontent.com/6582364/173240524-e353e3fe-6d9a-462f-b9e9-7fc5badc9b08.png)

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [ ] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
