### PR TITLE
Add clk.ink (clk.asia) bypass

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2714,7 +2714,7 @@ domainBypass("acorta-link.com", () => {
 domainBypass("clk.asia", () => {
     ensureDomLoaded(() => {
       const token = document.querySelector('#link-view [name="token"]').value;
-      const decoded = atob(token.substring(token.indexOf("aH")));
+      const decoded = atob(token.substring(token.indexOf("aHR0")));
       const page = decoded.split("http").pop();
       const link = `http${page}`;
       safelyNavigate(link);

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2711,6 +2711,16 @@ domainBypass("acorta-link.com", () => {
     })
 })
 
+domainBypass("clk.asia", () => {
+    ensureDomLoaded(() => {
+      const token = document.querySelector('#link-view [name="token"]').value;
+      const decoded = atob(token.substring(token.indexOf("aH")));
+      const page = decoded.split("http").pop();
+      const link = `http${page}`;
+      safelyNavigate(link);
+    });
+  });
+
 	//Insertion point for bypasses detecting certain DOM elements. Bypasses here will no longer need to call ensureDomLoaded.
 	domainBypass('letsboost.net', () => {
 		return safelyAssign(JSON.parse(stepDat).pop().url)


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: #405 
I added a working bypass. clk.ink redirects automatically to clk.asia, so I bypassed clk.asia. Example link (leads to utorrent site): https://clk.ink/Utorrent

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [ ] Tested on Firefox

\* indicates required
