### PR TITLE
Fixed fx4vip bypass

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -1523,7 +1523,7 @@ ensureDomLoaded(()=>{
 	})
 	domainBypass("fx4vip.com", () => {
 		ensureDomLoaded(() => {
-		ifElement("#button1", a => {
+		ifElement("#get_link", a => {
 			a.removeAttribute("disabled");
 			a.click();
 		})


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: Link to issue

<!-- I fixed the fx4vip bypass which is necessary for linkjust bypass. Current fx4vip bypass didn't work anymore but I fixed the problem now. Example link (redirects to google.com): https://linkjust.com/testfastigg -->

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [ ] Tested on Firefox

\* indicates required
