### PR TITLE
fixed tei.ai bypass (some links werent working)

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2706,7 +2706,7 @@ domainBypass('apkadmin.com', () => {
 
 	domainBypass("tei.ai", () => {
 		const token = document.querySelector('#link-view [name="token"]').value;
-		const decoded = atob(token.substring(token.indexOf("aH")));
+		const decoded = atob(token.substring(token.indexOf("aHR0")));
 		const page = decoded.split('http').pop();
 		const link = `http${page}`;
 		safelyNavigate(link);


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: Link to issue

<!-- Some tei.ai links werent working because the index "aH" was found two times. I added two more letters and now it should fix this issue and bypass more links  -->

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [ ] Tested on Firefox

\* indicates required
