### PR TITLE
Add bypass for crackedappsstore.com

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -877,6 +877,7 @@ hrefBypass(/(bluemediafiles\.com|pcgamestorrents.org)\/url-generator\.php\?url=/
 	awaitElement("input#nut[src]",i=>i.parentNode.submit())
 })
 //Insertion point for bypasses running before the DOM is loaded.
+hrefBypass(/https:\/\/crackedappsstore\.com\/(?:\\.|[^\\])*\/\?download.*/gm, () => ifElement("a.downloadAPK.dapk_b[href]", a => safelyAssign(a.href)))
 domainBypass("downloadr.in",()=>safelyNavigate(new URL(location.href).search.slice(1)))
 domainBypass(/^((www\.)?((njiir|healthykk|linkasm|dxdrive|getwallpapers|sammobile|ydfile|mobilemodsapk|dlandroid|download\.modsofapk)\.com|(punchsubs|zedge|fex)\.net|k2s\.cc|muhammadyoga\.me|u\.to|skiplink\.io|(uploadfree|freeupload)\.info|fstore\.biz))$/,()=>window.setInterval=f=>setInterval(f,1))
 hrefBypass(/thesimsresource\.com\/downloads\/details\/id\//,()=>window.setTimeout=f=>setTimeout(f,1))


### PR DESCRIPTION
Sample link - https://crackedappsstore.com/driving-school-sim/?download=links

<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: Link to issue

<!-- A brief description of what you did -->

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
