### PR TITLE
add check + infobox when trying to bypass linkvertise on non url

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -921,6 +921,9 @@ domainBypass(/linkvertise\.(com|net)|link-to\.net/, () => {
 
 
 				fetch(`https://publisher.linkvertise.com/api/v1/redirect/link/static${linkvertise_link}?X-Linkvertise-UT=${ut}`).then(r => r.json()).then(json => {
+					if (json?.data.link.target_type !== 'URL') {
+						return insertInfoBox('Due to copyright reasons we are not bypassing linkvertise stored content (paste, download etc)');
+					}
 					if (json?.data.link.id) {
 						const json_body = {
 							serial: btoa(JSON.stringify({


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: people complaining: linkvertise is not working, not bypassing this (points to linkvertise)

<!-- A brief description of what you did -->

<!--Add an x to mark as done-->
- [ x ] I made sure there are no unnecessary changes in the code*
- [ x ] Tested on Chromium- Browser OS
- [ x ] Tested on Firefox

\* indicates required

![image](https://user-images.githubusercontent.com/6582364/188446858-916932d1-5450-4c98-909f-8bc45dc51bd4.png)
