### PR TITLE
infoboxes could get big, now deleting after 7 seconds

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -321,8 +321,9 @@ insertInfoBox=text=>ensureDomLoaded(()=>{
 	div.setAttribute("aria-hidden","true")
 	const span=div.querySelector("span")
 	span.textContent=text
-	div.onclick=()=>document.body.removeChild(div)
+	div.onclick=()=>infobox_container.removeChild(div)
 	infobox_container.appendChild(div)
+	setTimeout(()=>infobox_container.removeChild(div), 7000);
 }),
 backgroundScriptBypassClipboard=c=>{
 	if(c)


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>


Fixes: no issue linked

<!-- A brief description of what you did -->
when getting multiple infoboxes the screen can get cluttered, the click to close was not working, now also autoclosing after 7 seconds

<!--Add an x to mark as done-->
- [ x ] I made sure there are no unnecessary changes in the code*
- [ x ] Tested on Chromium- Browser OS
- [ x ] Tested on Firefox

\* indicates required
