### PR TITLE
Add bypass for retrospring

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -886,6 +886,10 @@ hrefBypass(/(bluemediafiles\.com|pcgamestorrents.org)\/url-generator\.php\?url=/
 	transparentProperty("Time_Start",t=>t-5000)
 	awaitElement("input#nut[src]",i=>i.parentNode.submit())
 })
+const retrospringRegex = /\bretrospring\.net\/linkfilter\?url=/;
+hrefBypass(retrospringRegex, () => {
+	safelyNavigate(decodeURIComponent(document.URL.split(retrospringRegex)[1]))
+})
 //Insertion point for bypasses running before the DOM is loaded.
 hrefBypass(/https:\/\/crackedappsstore\.com\/(?:\\.|[^\\])*\/\?download.*/gm, () => ifElement("a.downloadAPK.dapk_b[href]", a => safelyAssign(a.href)))
 domainBypass("downloadr.in",()=>safelyNavigate(new URL(location.href).search.slice(1)))


### PR DESCRIPTION
<details> <summary>NOTICE</summary>
I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.
</details>

Adds bypass for retrospring (ex: https://retrospring.net/linkfilter?url=https%3A%2F%2Fold.reddit.com%2Fr%2FEldenring%2Fcomments%2Ftks52s%2Fage_of_the_stars_ending_mistranslations_and_my%2Fi1y1y66%2F)

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [ ] Tested on Firefox

\* indicates required
