### PR TITLE
Fix tinyurl.so

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -1786,7 +1786,7 @@ ensureDomLoaded(() => {
     domainBypass("adbull.me", () => ifElement("form#setc", ({ action }) => {
         unsafelyAssignWithReferer(location.href, action)
     }))
-    domainBypass("tinyurl.is", () => ifElement('a[id^="newskip-btn"][href]', safelyAssign))
+    domainBypass(/tinyurl\.(is|so)/, () => ifElement('a[id^="newskip-btn"][href]', safelyAssign))
     domainBypass("journaldupirate.net", () => {
         ifElement("div.alert a", safelyNavigate, () => {
             $(".button-blue").first().click()


### PR DESCRIPTION
Fixes: #782

Tinyurl changed domain from `tinyurl.is` to `tinyurl.so`

#782 is closed prematurely, please help to merge this PR, thank you for your help.

- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS Chrome 108.0.5359.98 (Official Build)
- [x] Tested on Firefox 108.0

\* indicates required
