### PR TITLE
Fixed grammatical errors

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -42,7 +42,7 @@
 		"message": "Options"
 	},
 	"optionsLink": {
-		"message": "Change FastForward' options."
+		"message": "Change FastForward's options."
 	},
 	"optionsEnabled": {
 		"message": "Enable website bypasses."
@@ -108,7 +108,7 @@
 		"message": "You are being navigated to %"
 	},
 	"infoLinkvertise": {
-		"message": "FastForward requires you to complete the captcha before we can bypass this site for you. after you do this, we can skip the annoying steps!"
+		"message": "FastForward requires you to complete the captcha before we can bypass this site for you. After you do so, we can skip the annoying steps!"
 	},
 	"infoFileHoster": {
 		"message": "Unfortunately, the download server will ensure that you have waited before allowing you to download the file."


### PR DESCRIPTION
Fixes: \<no issue\>

Fixed a grammatical error and reworded a sentence. The former was caused by mass-replacing `UniversalBypass` with `FastForward`. The latter contained an uncapitalized sentence and was overall worded weirdly. 

- [x] I made sure there are no unnecessary changes in the code*
- [ ] Tested on Chromium- Browser OS
- [ ] Tested on Firefox
