### PR TITLE
Update injection_script.js

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2579,7 +2579,24 @@ ensureDomLoaded(() => {
             }
         })
     })
-
+	// acortalink.me or allcalidad.is url shortener Fabian222005
+	domainBypass("acortalink.me", () => {
+	    function rot13(str) {
+		  var input     = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+		  var output    = 'NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm';
+		  var index     = x => input.indexOf(x);
+		  var translate = x => index(x) > -1 ? output[index(x)] : x;
+		  return str.split('').map(translate).join('');
+		}
+		// Triggered on example.com and subdomains (e.g. www.example.com)
+		ensureDomLoaded(() => {
+			// Triggered as soon as the DOM is ready
+			window.open = (linkacorta) => {
+			    safelyNavigate(rot13(atob(linkacorta.substring(30))));
+			};
+			GetLink();
+		})
+	})
     domainBypass("clk.asia", () => {
         ensureDomLoaded(() => {
             const token = document.querySelector('#link-view [name="token"]').value;


### PR DESCRIPTION
I add the bypass script for acortalink.me.  By rewriting the function of window.open to trigger safelyNavigate.

Fixes: New bypass for acortalink,com

It works by rewriting the window.open function and triggering the redirect with GetLink() func that is part of the website, the redirect is to here https://acortalink.me/s.php?i={b64 and then rot13 encoded}, is only trimmed at the start position (padding 30)

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [ ] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
