### PR TITLE
Add liblink.pl (Librus Synergia - Polish E-Register)

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2628,6 +2628,13 @@ ensureDomLoaded(() => {
             safelyNavigate(destination)
         })
     })
+    
+    // liblink.pl (Librus)
+    domainBypass("liblink.pl", () => {
+        ifElement("body > div > h1 > span", a => {
+	    safelyNavigate(a.innerHTML)
+        })
+    })
 
     //Insertion point for bypasses detecting certain DOM elements. Bypasses here will no longer need to call ensureDomLoaded.
     domainBypass(/cb\.(run|click)/, () => ifElement("a.btn", a => safelyAssign(a.href)))


### PR DESCRIPTION
Fixes: (no issue)

<!-- A brief description of what you did -->

Added https://liblink.pl support - a link shortener for the Polish e-register Librus Synergia which just warns you about leaving their website and is very annoying.

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

\* indicates required
