### PR TITLE
Add domain for BlueMediaFile bypass

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -802,7 +802,7 @@ hrefBypass(/daominhha\.com\/download/, () => {
     str = str.replaceAll(",", "=");
     safelyAssign(atob(str));
 });
-hrefBypass(/(bluemediafiles\.com|pcgamestorrents.org)\/url-generator\.php\?url=/, () => {
+hrefBypass(/(bluemediafiles\.com|pcgamestorrents\.org|bluemediafile\.sbs)\/url-generator\.php\?url=/, () => {
     window.setInterval = f => setInterval(f, 1)
     transparentProperty("Time_Start", t => t - 5000)
     awaitElement("input#nut[src]", i => i.parentNode.submit())


### PR DESCRIPTION
**Fixes**: #860 

**Description**: Added a new domain (`bluemediafile.sbs`) for the BlueMediaFile bypass. Also fixed the potential RegEx syntax error not matching `pcgamestorrents.org`.

**Test links**:
- [`bluemediafile.sbs` (prefix `+F30`)](https://bluemediafile.sbs/url-generator.php?url=+F30sKVGya5zG++539sIDeknUvP7uCWirMMYS0undWjwizvZTIxdeCQywNXUvAupkYoMa6QvLZJo07Fpj9DKtRJs64+8n32yBxvXjAdzH08=)
- [`bluemediafile.sbs` (prefix `onAh`)](https://bluemediafile.sbs/url-generator.php?url=onAhF5ZLCDGjfP3AAUIv/XlRmDn+wudFEkfnJ7uEgBeXyLVMsYWTpExvXrNN/Guf56DMAFDI5wZVhHZPGbZ4MaFoiu6moxU62KSR1rAfIS1i5htk/QMZqfg7jt3wJVok)

**Checklist**:
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox
