### PR TITLE
fix firefox building

### DIFF
--- a/scripts/build_js/chromium.js
+++ b/scripts/build_js/chromium.js
@@ -19,5 +19,5 @@ module.exports = async function ({versioning, destination, commit_number, versio
         output_file += `FastForward_${version}_chromium.crx`;
 
     await z.writeZipPromise(output_file, {});
-    console.log('[FastForward.build.chromium] Succesfull build the Chromium package: %s', output_file)
+    console.log('[FastForward.build.chromium] Succesfully built the Chromium package: %s', output_file)
 }

--- a/scripts/build_js/firefox.js
+++ b/scripts/build_js/firefox.js
@@ -9,11 +9,11 @@ module.exports = async function ({versioning, destination, commit_number, versio
     console.log(`[FastForward.build.firefox] building the FireFox package`);
     const z = new zipper();
 
-    console.log(`[FastForward.build.firefox] injecting the linkvertise bypass`);
-
-    const bypass = await fs.readFile(`${process.cwd()}/src/linkvertise.js`);
-
-    await fs.appendFile(`${process.cwd()}/build/FastForward.firefox/injection_script.js`, bypass);
+//    console.log(`[FastForward.build.firefox] injecting the linkvertise bypass`);
+//
+//    const bypass = await fs.readFile(`${process.cwd()}/src/linkvertise.js`);
+//
+//    await fs.appendFile(`${process.cwd()}/build/FastForward.firefox/injection_script.js`, bypass);
 
     z.addLocalFolder(`${process.cwd()}/${destination}`);
 
@@ -27,5 +27,5 @@ module.exports = async function ({versioning, destination, commit_number, versio
         output_file += `FastForward_${version}_firefox.xpi`;
 
     await z.writeZipPromise(output_file, {});
-    console.log('[FastForward.build.firefox] Succesfull build the FireFox package: %s', output_file)
+    console.log('[FastForward.build.firefox] Succesfully built the FireFox package: %s', output_file)
 }

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2824,6 +2824,59 @@ ensureDomLoaded(() => {
         }
         //Insertion point for bypasses detecting certain DOM elements which may appear up to 10 seconds after page load. Bypasses here will no longer need to call ensureDomLoaded.
         domainBypass("www.tech2learners.com", () => safelyNavigate(downloadButton.href))
+        domainBypass(/linkvertise\.(com|net)|link-to\.net/, () => {
+            if (window.location.href.toString().indexOf("?r=") != -1) {
+                const urlParams = new URLSearchParams(window.location.search);
+                const r = urlParams.get('r')
+                safelyNavigate(atob(decodeURIComponent(r)));
+            }
+        
+            const rawOpen = XMLHttpRequest.prototype.open;
+        
+            XMLHttpRequest.prototype.open = function() {
+                this.addEventListener('load', data => {
+                    if (data.currentTarget.responseText.includes('tokens')) {
+                        const response = JSON.parse(data.currentTarget.responseText);
+                        if (!response.data.valid)
+                            return insertInfoBox('Please solve the captcha, afterwards we can immediately redirect you');
+        
+                        const target_token = response.data.tokens['TARGET'];
+                        const ut = localStorage.getItem("X-LINKVERTISE-UT");
+                        const linkvertise_link = location.pathname.replace(/\/[0-9]$/, "");
+        
+        
+                        fetch(`https://publisher.linkvertise.com/api/v1/redirect/link/static${linkvertise_link}?X-Linkvertise-UT=${ut}`).then(r => r.json()).then(json => {
+                            if (json?.data.link.target_type !== 'URL') {
+                                return insertInfoBox('Due to copyright reasons we are not bypassing linkvertise stored content (paste, download etc)');
+                            }
+                            if (json?.data.link.id) {
+                                const json_body = {
+                                    serial: btoa(JSON.stringify({
+                                        timestamp:new Date().getTime(),
+                                        random:"6548307",
+                                        link_id:json.data.link.id
+                                    })),
+                                    token: target_token
+                                }
+                                fetch(`https://publisher.linkvertise.com/api/v1/redirect/link${linkvertise_link}/target?X-Linkvertise-UT=${ut}`, {
+                                    method: "POST",
+                                    body: JSON.stringify(json_body),
+                                    headers: {
+                                        "Accept": 'application/json',
+                                        "Content-Type": 'application/json'
+                                    }
+                                }).then(r=>r.json()).then(json=>{
+                                    if (json?.data.target) {
+                                        safelyNavigate(json.data.target)
+                                    }
+                                })
+                            }
+                        })
+                    }
+                });
+                rawOpen.apply(this, arguments);
+            }
+        })
     }, 100)
     setTimeout(() => clearInterval(dT), 10000)//
 }, true)


### PR DESCRIPTION
add linkvertise back to injectionscript, remove bypass injection from build.js in order to fix firefox building (before it was just making a file with only the linkvertise bypass)

REQUIRES ["fix chromium building"](https://github.com/FastForwardTeam/FastForward/pull/882)

Checklist:
<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

<!--\* indicates required -->
