### PR TITLE
Add message telling user to ignore mv2 warning

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -58,6 +58,8 @@ resetCounter=()=>{
 	sendToOptions({bypassCounter})
 }
 
+if(typeof chrome !== 'undefined') console.warn("The message above can be ignored as it is not an issue. Press the 'Clear all' button.");
+
 // Install handler
 brws.runtime.onInstalled.addListener(details=>{
 	if(details.reason=="install")


### PR DESCRIPTION
Add message telling user to ignore mv2 warning

<!-- A link to all issues that this pull request will address, 
Link all issues with the number, like #123. Put "None" if you are making a new bypass-->
Fixes (Links to issues fixed by this PR): 
None

<!-- A brief description of what you did. Write the sites you bypassed and what changes/ additions to the source code.
Don't worry about this being too long, we care more about the code than your writing skills 😉-->
Description:
Added warning message when the extension first loads telling the user that they can ignore the mv2 warning, as it won't cause any problems.

Checklist:
<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [ ] Tested on Firefox

<!--\* indicates required -->
