### PR TITLE
[Temp Fix] Stop bypassing `megadb.net`

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -1900,11 +1900,11 @@ ensureDomLoaded(() => {
             }
         }
     })
-    domainBypass("megadb.net", () => {
-        ifElement("form[name='F1']", function (a) {
-            a.submit();
-        });
-    });
+//     domainBypass("megadb.net", () => {
+//         ifElement("form[name='F1']", function (a) {
+//             a.submit();
+//         });
+//     });
     hrefBypass(/enxf\.net\/resources\/[a-zA-Z-\.\d]+\/download/, () => {
         ifElement(".XGT-Download-form", ex => safelyNavigate(ex.action));
     })


### PR DESCRIPTION
<!-- A link to all issues that this pull request will address, 
Link all issues with the number, like #123. Put "None" if you are making a new bypass-->
Fixes (Links to issues fixed by this PR): #610

<!-- A brief description of what you did. Write the sites you bypassed and what changes/ additions to the source code.
Don't worry about this being too long, we care more about the code than your writing skills 😉-->
Description: AFAIK there is no current working script that bypasses `megadb.net`'s countdown. I even personally digged in source code of `megadb.net/download` to search for ways to bypass but couldn't find anything so I think that it's all server sided, meaning that client side can't bypass countdown. I could be wrong and it's my poor skills that can't detect bypass method but currently nobody has written it and it's also annoying to constantly switch on and off **FastForward** extension to download from `megadb.net`, so I temporally commented `megadb.net`'s bypass code in [**injection_script.js**](https://github.com/UltraStudioLTD/FastForward/blob/5011ab2e99a12b7b23074493a3448e08ab21f54d/src/js/injection_script.js#L1903-L1907)

<!-- Add test links for all sites in the pull request. Make sure to link one test link per site
Make sure to hyperlink test links to avoid making the PR look messy
To make a hyperlink, the format is [domain name](direct link)-->
Test links: [megadb.net](https://megadb.net/download)

> **Note**
> `https://megadb.net/*` links are automatically redirected to `https://megadb.net/download`


Checklist:
<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

<!--\* indicates required -->
