### PR TITLE
fix bypass detection in krnl.place

### DIFF
--- a/src/html/before-navigate.js
+++ b/src/html/before-navigate.js
@@ -13,11 +13,17 @@ if(args.has("target"))
 			{
 				document.querySelector("div").innerHTML="<p></p>"
 				document.querySelector("p").textContent=brws.i18n.getMessage("beforeNavigateInstant").replace("%",args.get("target"))
-				setTimeout(()=>location.href=a.href,10)
+				setTimeout(()=>{
+					chrome.runtime.sendMessage({ type: "open-tab", url: a.href })
+					chrome.runtime.sendMessage({ type: "close-tab" })
+				},10)
 			}
 			else
 			{
-				timer("beforeNavigateTimer",res.navigation_delay,true,()=>location.href=a.href)
+				timer("beforeNavigateTimer",res.navigation_delay,true,()=>{
+					chrome.runtime.sendMessage({ type: "open-tab", url: a.href })
+					chrome.runtime.sendMessage({ type: "close-tab" })
+				})
 			}
 		})
 	}

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -59,6 +59,9 @@ unsafelyNavigate=target=>{
 		case (/krnl\.ca/.exec(target)||{}).input:
 		url+="&safe_in=15"
 		break;
+		case (/hugegames\.io/.exec(target)||{}).input:
+		url+="&safe_in=15"
+		break;
 	}
 	unsafelyAssign(url)
 },

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -56,10 +56,7 @@ unsafelyNavigate=target=>{
 	let url="https://universal-bypass.org/bypassed?target="+encodeURIComponent(target)+"&referer="+encodeURIComponent(referer)
 	switch(target)//All values here have been tested using "Take me to destinations after 0 seconds."
 	{
-		case (/krnl\.ca/.exec(target)||{}).input:
-		url+="&safe_in=15"
-		break;
-		case (/hugegames\.io/.exec(target)||{}).input:
+		case (/(krnl\.ca|hugegames\.io)/.exec(target)||{}).input:
 		url+="&safe_in=15"
 		break;
 	}


### PR DESCRIPTION
<!-- A link to all issues that this pull request will address, 
Link all issues with the number, like #123. Put "None" if you are making a new bypass-->
Fixes (Links to issues fixed by this PR): 
krnl.place bypass detection (no issues were made)
<!-- A brief description of what you did. Write the sites you bypassed and what changes/ additions to the source code.
Don't worry about this being too long, we care more about the code than your writing skills 😉-->
Description:
krnl.place has a bypass detector and this was fixed by opening the target tab (linkvertise target) and then closing the calling tab (the before-navigate page). i think this removes the referrer header and that was probably used to check for bypassing.
<!-- Add test links for all sites in the pull request. Make sure to link one test link per site
Make sure to hyperlink test links to avoid making the PR look messy
To make a hyperlink, the format is [domain name](direct link)-->
Test links:
[krnl getkey](https://cdn.krnl.place/getkey) (copy link and paste in new tab)

Checklist:
<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

<!--\* indicates required -->
