### PR TITLE
add support for linkvertise pastes

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2828,59 +2828,126 @@ ensureDomLoaded(() => {
         }
         //Insertion point for bypasses detecting certain DOM elements which may appear up to 10 seconds after page load. Bypasses here will no longer need to call ensureDomLoaded.
         domainBypass("www.tech2learners.com", () => safelyNavigate(downloadButton.href))
-        domainBypass(/linkvertise\.(com|net)|link-to\.net/, () => {
-            if (window.location.href.toString().indexOf("?r=") != -1) {
-                const urlParams = new URLSearchParams(window.location.search);
-                const r = urlParams.get('r')
-                safelyNavigate(atob(decodeURIComponent(r)));
-            }
-        
-            const rawOpen = XMLHttpRequest.prototype.open;
-        
-            XMLHttpRequest.prototype.open = function() {
-                this.addEventListener('load', data => {
-                    if (data.currentTarget.responseText.includes('tokens')) {
-                        const response = JSON.parse(data.currentTarget.responseText);
-                        if (!response.data.valid)
-                            return insertInfoBox('Please solve the captcha, afterwards we can immediately redirect you');
-        
-                        const target_token = response.data.tokens['TARGET'];
-                        const ut = localStorage.getItem("X-LINKVERTISE-UT");
-                        const linkvertise_link = location.pathname.replace(/\/[0-9]$/, "");
-        
-        
-                        fetch(`https://publisher.linkvertise.com/api/v1/redirect/link/static${linkvertise_link}?X-Linkvertise-UT=${ut}`).then(r => r.json()).then(json => {
-                            if (json?.data.link.target_type !== 'URL') {
-                                return insertInfoBox('Due to copyright reasons we are not bypassing linkvertise stored content (paste, download etc)');
-                            }
-                            if (json?.data.link.id) {
-                                const json_body = {
-                                    serial: btoa(JSON.stringify({
-                                        timestamp:new Date().getTime(),
-                                        random:"6548307",
-                                        link_id:json.data.link.id
-                                    })),
-                                    token: target_token
-                                }
-                                fetch(`https://publisher.linkvertise.com/api/v1/redirect/link${linkvertise_link}/target?X-Linkvertise-UT=${ut}`, {
-                                    method: "POST",
-                                    body: JSON.stringify(json_body),
-                                    headers: {
-                                        "Accept": 'application/json',
-                                        "Content-Type": 'application/json'
-                                    }
-                                }).then(r=>r.json()).then(json=>{
-                                    if (json?.data.target) {
-                                        safelyNavigate(json.data.target)
-                                    }
-                                })
-                            }
-                        })
-                    }
-                });
-                rawOpen.apply(this, arguments);
-            }
-        })
+	domainBypass(/linkvertise\.(com|net)|link-to\.net/, () => {
+	    if (window.location.href.toString().indexOf("?r=") != -1) {
+		const urlParams = new URLSearchParams(window.location.search)
+		const r = urlParams.get("r")
+		safelyNavigate(atob(decodeURIComponent(r)))
+	    }
+
+	    const rawOpen = XMLHttpRequest.prototype.open
+
+	    XMLHttpRequest.prototype.open = function () {
+		this.addEventListener("load", (data) => {
+		    if (data.currentTarget.responseText.includes("tokens")) {
+			const response = JSON.parse(data.currentTarget.responseText)
+			if (!response.data.valid)
+			    return insertInfoBox(
+				"Please solve the captcha, afterwards we can immediately redirect you"
+			    )
+
+			const target_token = response.data.tokens["TARGET"]
+			const ut = localStorage.getItem("X-LINKVERTISE-UT")
+			const linkvertise_link = location.pathname.replace(
+			    /\/[0-9]$/,
+			    ""
+			)
+
+			fetch(
+			    `https://publisher.linkvertise.com/api/v1/redirect/link/static${linkvertise_link}?X-Linkvertise-UT=${ut}`
+			)
+			    .then((r) => r.json())
+			    .then((json) => {
+				if (json?.data.link.target_type !== "URL") {
+				    insertInfoBox("Paste detected, bypassing..")
+				    // what is referred to as the pathmap is a table of functions to bypass for each type of content.
+				    let pathmap = {
+					"PASTE": function () {
+					    if (json?.data.link.id) {
+						const json_body = {
+						    serial: btoa(
+							JSON.stringify({
+							    timestamp:
+								new Date().getTime(),
+							    random: "6548307",
+							    link_id: json.data.link.id,
+							})
+						    ),
+						    token: target_token,
+						}
+						fetch(
+						    `https://publisher.linkvertise.com/api/v1/redirect/link${linkvertise_link}/paste?X-Linkvertise-UT=${ut}`,
+						    {
+							method: "POST",
+							body: JSON.stringify(json_body),
+							headers: {
+							    Accept: "application/json",
+							    "Content-Type":
+								"application/json",
+							},
+						    }
+						)
+						    .then((r) => r.json())
+						    .then((json) => {
+							if (json?.data.paste) {
+							    insertInfoBox("Bypassed, attempting to copy to clipboard.")
+							    navigator.clipboard.writeText(json?.data.paste).then(function() {
+							      insertInfoBox("Copied paste to clipboard!\nYou may now close this tab.")
+							    }, (err) => {
+							      window.prompt("Copying to clipboard failed!\nThe paste is displayed below. Ctrl+C to copy it.", json?.data.paste)
+							    });
+							}
+						    })
+					    }
+					},
+				    }
+				    if (
+					!pathmap.hasOwnProperty(
+					    json?.data.link.target_type
+					)
+				    ) {
+					return insertInfoBox(
+					    "Due to copyright reasons we are not bypassing linkvertise stored content (paste, download etc)"
+					)
+				    }
+				    return pathmap[json?.data.link.target_type]()
+				}
+				if (json?.data.link.id) {
+				    const json_body = {
+					serial: btoa(
+					    JSON.stringify({
+						timestamp: new Date().getTime(),
+						random: "6548307",
+						link_id: json.data.link.id,
+					    })
+					),
+					token: target_token,
+				    }
+				    fetch(
+					`https://publisher.linkvertise.com/api/v1/redirect/link${linkvertise_link}/target?X-Linkvertise-UT=${ut}`,
+					{
+					    method: "POST",
+					    body: JSON.stringify(json_body),
+					    headers: {
+						Accept: "application/json",
+						"Content-Type": "application/json",
+					    },
+					}
+				    )
+					.then((r) => r.json())
+					.then((json) => {
+					    if (json?.data.target) {
+						safelyNavigate(json.data.target)
+					    }
+					})
+				}
+			    })
+		    }
+		})
+		rawOpen.apply(this, arguments)
+	    }
+	})
+
         domainBypass("fssquad.com", () => {
           ensureDomLoaded(() => {
             ifElement("div#wpsafe-link", d => {


### PR DESCRIPTION
<!-- A link to all issues that this pull request will address, 
Link all issues with the number, like #123. Put "None" if you are making a new bypass-->
Fixes (Links to issues fixed by this PR): 
None
<!-- A brief description of what you did. Write the sites you bypassed and what changes/ additions to the source code.
Don't worry about this being too long, we care more about the code than your writing skills 😉-->
Description:
bypasses linkvertise's pasting feature. basically i just added a check for pastes and if it matches it will get the info almost exactly like the url bypass except it copies the paste instead of redirecting.
<!-- Add test links for all sites in the pull request. Make sure to link one test link per site
Make sure to hyperlink test links to avoid making the PR look messy
To make a hyperlink, the format is [domain name](direct link)-->
Test links:
[LinkvertisePaste](https://linkvertise.com/114822/test?o=sharing)
Checklist:
<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [ ] Tested on Firefox

<!--\* indicates required -->
