### PR TITLE
Added a modular system for bypassing different linkvertise content types and added a paste bypass.

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2853,9 +2853,9 @@ ensureDomLoaded(() => {
                             let target_type = json?.data.link.target_type
                             const make_serial = () => {
                                 return btoa(JSON.stringify({
-                                    timestamp:new Date().getTime(),
-                                    random:"6548307",
-                                    link_id:json.data.link.id
+                                    timestamp: new Date().getTime(),
+                                    random: "6548307",
+                                    link_id: json.data.link.id
                                 }))
                             }
                             const pathmap = {
@@ -2898,7 +2898,7 @@ ensureDomLoaded(() => {
                                                 setTimeout(() => {
                                                     window.location.href =
                                                     URL.createObjectURL(
-                                                        new Blob([json?.data.paste], { type: "text/plain" })
+                                                        new Blob([json.data.paste], { type: "text/plain" })
                                                     )
                                                 }, 3000)
                                             }
@@ -2907,7 +2907,7 @@ ensureDomLoaded(() => {
                                 }
                             }
                             if (!pathmap.hasOwnProperty(target_type))
-                                return insertInfoBox('Due to copyright reasons we are not bypassing linkvertise stored content (paste, download etc)');
+                                return insertInfoBox(`We currently do not support the "${target_type}" linkvertise type.\nOpen an issue on github to request that we add this type.`);
                             return pathmap[target_type]()
                         })
                     }

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -2850,31 +2850,65 @@ ensureDomLoaded(() => {
         
         
                         fetch(`https://publisher.linkvertise.com/api/v1/redirect/link/static${linkvertise_link}?X-Linkvertise-UT=${ut}`).then(r => r.json()).then(json => {
-                            if (json?.data.link.target_type !== 'URL') {
-                                return insertInfoBox('Due to copyright reasons we are not bypassing linkvertise stored content (paste, download etc)');
+                            let target_type = json?.data.link.target_type
+                            const make_serial = () => {
+                                return btoa(JSON.stringify({
+                                    timestamp:new Date().getTime(),
+                                    random:"6548307",
+                                    link_id:json.data.link.id
+                                }))
                             }
-                            if (json?.data.link.id) {
-                                const json_body = {
-                                    serial: btoa(JSON.stringify({
-                                        timestamp:new Date().getTime(),
-                                        random:"6548307",
-                                        link_id:json.data.link.id
-                                    })),
-                                    token: target_token
+                            const pathmap = {
+                                "URL": () => {
+                                    if (json?.data.link.id) {
+                                        const json_body = {
+                                            serial: make_serial(),
+                                            token: target_token
+                                        }
+                                        fetch(`https://publisher.linkvertise.com/api/v1/redirect/link${linkvertise_link}/target?X-Linkvertise-UT=${ut}`, {
+                                            method: "POST",
+                                            body: JSON.stringify(json_body),
+                                            headers: {
+                                                "Accept": 'application/json',
+                                                "Content-Type": 'application/json'
+                                            }
+                                        }).then(r=>r.json()).then(json=>{
+                                            if (json?.data.target) {
+                                                safelyNavigate(json.data.target)
+                                            }
+                                        })
+                                    }
+                                },
+                                "PASTE": () => {
+                                    if (json?.data.link.id) {
+                                        const json_body = {
+                                            serial: make_serial(),
+                                            token: target_token
+                                        }
+                                        fetch(`https://publisher.linkvertise.com/api/v1/redirect/link${linkvertise_link}/paste?X-Linkvertise-UT=${ut}`, {
+                                            method: "POST",
+                                            body: JSON.stringify(json_body),
+                                            headers: {
+                                                "Accept": 'application/json',
+                                                "Content-Type": 'application/json'
+                                            }
+                                        }).then(r=>r.json()).then(json=>{
+                                            if (json?.data.paste) {
+                                                insertInfoBox('Bypassed paste! Opening in 3 seconds..')
+                                                setTimeout(() => {
+                                                    window.location.href =
+                                                    URL.createObjectURL(
+                                                        new Blob([json?.data.paste], { type: "text/plain" })
+                                                    )
+                                                }, 3000)
+                                            }
+                                        })
+                                    }
                                 }
-                                fetch(`https://publisher.linkvertise.com/api/v1/redirect/link${linkvertise_link}/target?X-Linkvertise-UT=${ut}`, {
-                                    method: "POST",
-                                    body: JSON.stringify(json_body),
-                                    headers: {
-                                        "Accept": 'application/json',
-                                        "Content-Type": 'application/json'
-                                    }
-                                }).then(r=>r.json()).then(json=>{
-                                    if (json?.data.target) {
-                                        safelyNavigate(json.data.target)
-                                    }
-                                })
                             }
+                            if (!pathmap.hasOwnProperty(target_type))
+                                return insertInfoBox('Due to copyright reasons we are not bypassing linkvertise stored content (paste, download etc)');
+                            return pathmap[target_type]()
                         })
                     }
                 });


### PR DESCRIPTION
\#### continuation of #928 and #933, third time's the charm. (next time I should really only push when I'm 100% done) ####

<!-- A link to all issues that this pull request will address, 
Link all issues with the number, like #123. Put "None" if you are making a new bypass-->
Fixes (Links to issues fixed by this PR): 
None
<!-- A brief description of what you did. Write the sites you bypassed and what changes/ additions to the source code.
Don't worry about this being too long, we care more about the code than your writing skills 😉-->
Description:
bypasses linkvertise's pasting feature. basically i just added a check for pastes and if it matches it will get the info almost exactly like the url bypass ~~except it copies the paste instead of redirecting~~ but it redirects to a blob url of the paste text.
<!-- Add test links for all sites in the pull request. Make sure to link one test link per site
Make sure to hyperlink test links to avoid making the PR look messy
To make a hyperlink, the format is [domain name](direct link)-->
Test links:
[LinkvertisePaste](https://linkvertise.com/114822/test?o=sharing)
Checklist:
<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

<!--\* indicates required -->