### PR TITLE
Remove dev warning

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -23,9 +23,6 @@
 			<a class="uk-alert-close" uk-close></a>
 			<p data-message="firstrunTitle"></p>
 		</div>
-		<div id="dev-alert" class="uk-alert uk-alert-danger uk-hidden">
-			<p>You're using FastForward in development mode, which means that bypass definitions are loaded from your local injection_script.js and rules.json. If you would like to use the auto-updating system, delete those files and then check for updates.</p>
-		</div>
 		<div id="counter" class="uk-alert uk-alert-primary uk-hidden">
 			<p><span></span> <a href="https://discord.gg/RSAf7b5njt" target="_blank" data-message="support"></a></p>
 		</div>


### PR DESCRIPTION
<!-- Add test links for all sites in the pull request. Make sure to link one test link per site
Make sure to hyperlink test links to avoid making the PR look messy
To make a hyperlink, the format is [domain name](direct link)-->
Remove the dev warning so that users don't panic

#### How will we know if we're in dev mode then??
it says next to the version:
![image](https://user-images.githubusercontent.com/81463636/230105339-05a44e49-ee3d-4eaf-9e5b-0db74b1e5f63.png)


#### Why?
I created a tag and release workflow which releases a signed version of the extension for firefox [example](https://github.com/FastForwardTeam/FastForward/releases/tag/0.2235). I used the --channel=unlisted so mozilla signs the extension without a review. Now users are not required to use the nightly or developer version of Firefox to install the extension.  

#### Aren't we bypassing Mozilla' safety policies then?
No, the dev mode means the injection script is packed with extension. However, the background script does periodically send a request to github for new verision but it does not use them. This has already been fixed on the mv3 branch, no point in changing the background script for a soon-to-be deprecated version 

#### Why is the button stuck at "downloading bypass definitions..."?
Fixed (read removed entirely) on the mv3 branch, so again no point fixing it here


Checklist:
<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [ ] Tested on Chromium- Browser OS
- [x] Tested on Firefox

<!--\* indicates required -->
