### PR TITLE
Added bypass for howtofree and download.howtofree

### DIFF
--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -489,20 +489,26 @@ ODP(window, "adtival_base64_encode", {
 // New PRs with bypasses must be added below this comment //
 ///////////////////////////////////////////////////////////////////////////////////////
 
-domainBypass("howtofree.org", () => {
-    document.getElementsByClassName("hide")[1].className = "show";
+domainBypass("www.howtofree.org", () => {
+    ensureDomLoaded(() => {
+        document.getElementsByClassName("hide")[1].className = "show";
+    })
 })
 
 domainBypass("download.howtofree.org", () => {
-    [...document.getElementsByClassName("timer-button")].forEach((elem, index) => {
-        const button = document.createElement("button");
-        button.innerHTML = `Download Part ${index + 1}`;
-        button.style.margin = "12px";
-        button.onclick = () => {
-          window.open(elem.getAttribute("data-redirect"), "_blank");
-        };
-        elem.replaceWith(button);
-    });
+    ensureDomLoaded(() => {
+        [...document.getElementsByClassName("timer-button")].forEach((elem, index) => {
+            const button = document.createElement("button");
+
+            button.innerHTML = `Download Part ${index + 1}`;
+            button.style.margin = "12px";
+            button.onclick = () => {
+              window.open(elem.getAttribute("data-redirect"), "_blank");
+            };
+            
+            elem.replaceWith(button);
+        });
+    })
 })
 
 hrefBypass(/vk\.com\/away\.php\?to=.+/, () => {

--- a/src/js/injection_script.js
+++ b/src/js/injection_script.js
@@ -489,6 +489,22 @@ ODP(window, "adtival_base64_encode", {
 // New PRs with bypasses must be added below this comment //
 ///////////////////////////////////////////////////////////////////////////////////////
 
+domainBypass("howtofree.org", () => {
+    document.getElementsByClassName("hide")[1].className = "show";
+})
+
+domainBypass("download.howtofree.org", () => {
+    [...document.getElementsByClassName("timer-button")].forEach((elem, index) => {
+        const button = document.createElement("button");
+        button.innerHTML = `Download Part ${index + 1}`;
+        button.style.margin = "12px";
+        button.onclick = () => {
+          window.open(elem.getAttribute("data-redirect"), "_blank");
+        };
+        elem.replaceWith(button);
+    });
+})
+
 hrefBypass(/vk\.com\/away\.php\?to=.+/, () => {
     safelyNavigate(decodeURIComponent(document.URL.match(/vk\.com\/away\.php\?to=([^&]+)/)[1]));
 })


### PR DESCRIPTION
<!-- A link to all issues that this pull request will address, 
Link all issues with the number, like #123. Put "None" if you are making a new bypass-->
<!-- A brief description of what you did. Write the sites you bypassed and what changes/ additions to the source code.
Don't worry about this being too long, we care more about the code than your writing skills 😉-->
Description:
Added bypass to skip the 15-second timer on howtofree and the 4-second timer per link on download.howtofree.

<!-- Add test links for all sites in the pull request. Make sure to link one test link per site
Make sure to hyperlink test links to avoid making the PR look messy
To make a hyperlink, the format is [domain name](direct link)-->
Test links:
[howtofree](https://www.howtofree.org/learn-flutter-dart-to-build-ios-android-apps-2/)
[download.howtofree](https://download.howtofree.org/flutter-dart-the-complete-guide-2023-edition-)

Checklist:
<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code*
- [x] Tested on Chromium- Browser OS
- [x] Tested on Firefox

<!--\* indicates required -->
