### PR TITLE
add anonyviet bypass

### DIFF
--- a/src/bypasses/anonyviet.js
+++ b/src/bypasses/anonyviet.js
@@ -1,0 +1,18 @@
+import BypassDefinition from './BypassDefinition.js';
+
+export default class AnonyVietBypass extends BypassDefinition {
+    constructor() {
+        super();
+        this.ensure_dom = true
+    }
+
+    execute() {
+        const match = document.URL.match(/anonyviet\.com\/[^?]+\?url=([^&]+)/);
+        if (match) {
+            this.helpers.safelyNavigate(decodeURIComponent(match[1]));
+        }
+    }
+}
+
+export const matches = ['anonyviet.com/'];
+


### PR DESCRIPTION
Fix: 
Takes an URL such as: `https://anonyviet.com/tieptucdentrangmoi/?url=https%3A%2F%2Fsignup.microsoft.com%2Fsignup%3Fsku%3DEducation` and returns and opens `https://signup.microsoft.com/signup?sku=Education`.

Closes #1104 

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code;
- [ ] Tested on Chromium (Includes Opera, Brave, Vivaldi, Edge, etc);
- [ ] Tested on Firefox.
