### PR TITLE
fix: version number not showing up in firefox builds

### DIFF
--- a/src/html/options.js
+++ b/src/html/options.js
@@ -49,12 +49,11 @@ function addNumberInputs() {
 }
 
 function displayExtensionVersion() {
-  brws.storage.local
-    .get('version')
-    .then(
-      (data) =>
-        (document.getElementById('version').textContent = data.version + '-Mv3')
-    );
+  const versionElement = document.getElementById('version');
+  if (versionElement) {
+    const extensionVersion = brws.runtime.getManifest().version + '-Mv3';
+    versionElement.textContent = extensionVersion;
+  }
 }
 
 function formatWhitelistDesc() {


### PR DESCRIPTION
Fix(es): 
- version number not showing up in Firefox builds
<!-- A brief description of what you did -->

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code;
- [x] Tested on Chromium (Includes Opera, Brave, Vivaldi, Edge, etc);
- [x] Tested on Firefox.
