### PR TITLE
Update download extension icons in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 <a href="https://discord.gg/RSAf7b5njt" target="_blank"> <img alt="Discord" src="https://img.shields.io/discord/876622516607656006?label=Our%20Discord&logo=discord&style=for-the-badge"> </a>
 
 
-<a href="https://chromewebstore.google.com/detail/fastforward/icallnadddjmdinamnolclfjanhfoafe"><img src="https://user-images.githubusercontent.com/585534/107280622-91a8ea80-6a26-11eb-8d07-77c548b28665.png" alt="Get FastForward on Chromium based browsers" width="177"> </a>
+<a href="https://chromewebstore.google.com/detail/fastforward/icallnadddjmdinamnolclfjanhfoafe"><img src="https://i.imgur.com/pS1Vldh.png" alt="Get FastForward on Chromium based browsers" width="177"> </a>
 <a href="https://microsoftedge.microsoft.com/addons/detail/fastforward/ldcclmkclhomnpcnccgbgleikchbnecl"><img src="https://user-images.githubusercontent.com/585534/107280673-a5ece780-6a26-11eb-9cc7-9fa9f9f81180.png" alt="Get FastForward on Microsoft Edge" width="126px"></a>
-<a href="https://addons.mozilla.org/firefox/addon/fastforwardteam/"><img src="https://user-images.githubusercontent.com/585534/107280546-7b9b2a00-6a26-11eb-8f9f-f95932f4bfec.png" alt="Get FastForward for Firefox" width="126px"></a> 
+<a href="https://addons.mozilla.org/firefox/addon/fastforwardteam/"><img src="https://i.imgur.com/LzGz6jo.png" alt="Get FastForward for Firefox" width="126px"></a> 
 </div>
 
 > **We need developers to work on bypasses! If you're interested, [join our Discord](https://discord.gg/RSAf7b5njt).**

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 <a href="https://discord.gg/RSAf7b5njt" target="_blank"> <img alt="Discord" src="https://img.shields.io/discord/876622516607656006?label=Our%20Discord&logo=discord&style=for-the-badge"> </a>
 
 
-<a href="https://chromewebstore.google.com/detail/fastforward/icallnadddjmdinamnolclfjanhfoafe"><img src="https://i.imgur.com/pS1Vldh.png" alt="Get FastForward on Chromium based browsers" width="177"> </a>
-<a href="https://microsoftedge.microsoft.com/addons/detail/fastforward/ldcclmkclhomnpcnccgbgleikchbnecl"><img src="https://user-images.githubusercontent.com/585534/107280673-a5ece780-6a26-11eb-9cc7-9fa9f9f81180.png" alt="Get FastForward on Microsoft Edge" width="126px"></a>
-<a href="https://addons.mozilla.org/firefox/addon/fastforwardteam/"><img src="https://i.imgur.com/LzGz6jo.png" alt="Get FastForward for Firefox" width="126px"></a> 
+<a href="https://chromewebstore.google.com/detail/fastforward/icallnadddjmdinamnolclfjanhfoafe"><img src="https://raw.githubusercontent.com/FastForwardTeam/Assets/main/ext/chrome.png" alt="Get FastForward on Chromium based browsers" width="177"> </a>
+<a href="https://microsoftedge.microsoft.com/addons/detail/fastforward/ldcclmkclhomnpcnccgbgleikchbnecl"><img src="https://raw.githubusercontent.com/FastForwardTeam/Assets/main/ext/edge.png" alt="Get FastForward on Microsoft Edge" width="126px"></a>
+<a href="https://addons.mozilla.org/firefox/addon/fastforwardteam/"><img src="https://raw.githubusercontent.com/FastForwardTeam/Assets/main/ext/firefox.png" alt="Get FastForward for Firefox" width="126px"></a> 
 </div>
 
 > **We need developers to work on bypasses! If you're interested, [join our Discord](https://discord.gg/RSAf7b5njt).**


### PR DESCRIPTION
**Issue:** https://github.com/FastForwardTeam/FastForward/issues/1160

As stated in the Issue, I have both the square and rounded versions of the Chrome icon, here in this PR I opted to use the squared version (to be as similar as possible to the current icon), but I personally think the round icon looks the best, so maybe we could switch to that.

Another thing to note in this PR is that the colors of the old and new Firefox download icon are slightly different (the new one has a darker blue), but that is easy to modify since it is a high-quality PNG picture, it is a matter of copying the color of the old icon and applying it on the new one using Paint/Photoshop.

And last but not least, I wasn't sure what the convention for icons is for FastForward. I wasn't sure if the icons should be somewhere in the project's folder (like in the `docs` folder), or if it should be hosted externally. Since the current icons being used are from `user-images.githubusercontent.com` , I assumed the project wants to keep its icons externalized, so I uploaded them to `imgur.com` (but no clue if this was the preferred way).

Here's the upload link with all three icons: https://imgur.com/a/2luHAqC

**Fix(es):** 
There was no fix, this PR updates the Firefox and Chrome download icons in the project readme. 

<!--Add an x to mark as done-->
- [X] I made sure there are no unnecessary changes in the code;
- [ ] Tested on Chromium (Includes Opera, Brave, Vivaldi, Edge, etc);
- [ ] Tested on Firefox.