### PR TITLE
add: vebma.com, fix: miuiku.com, sekilastekno.com

### DIFF
--- a/docs/Bypassed.md
+++ b/docs/Bypassed.md
@@ -526,8 +526,8 @@ This is a list of websites bypassed in the MV2 version of the extension.
 |           https://liveshootv.com           |   🛑   | 
 |            https://modebaca.com            |   ❌    |
 |            https://haipedia.com            |   ❌    |
-|          https://sekilastekno.com          |   ❌    |
-|             https://miuiku.com             |   ❌    |
+|          https://sekilastekno.com          |   ✅    |
+|             https://miuiku.com             |   ✅    |
 |            https://shrink.world            |   🛑   | 
 |         https://link.mymastah.xyz          |   🛑   | 
 |             https://sportif.id             |   ❌    |
@@ -587,3 +587,4 @@ This is a list of websites bypassed in the MV2 version of the extension.
 |               https://oko.sh               |   ✅    |
 |           https://bluetechno.net           |   ✅    |
 |             https://work.click             |   ✅    |
+|             https://vebma.com             |   ✅    |

--- a/docs/Bypassed.md
+++ b/docs/Bypassed.md
@@ -588,3 +588,4 @@ This is a list of websites bypassed in the MV2 version of the extension.
 |           https://bluetechno.net           |   ✅    |
 |             https://work.click             |   ✅    |
 |             https://vebma.com             |   ✅    |
+|             https://adtival.network             |   ✅    |

--- a/src/bypasses/adtival.js
+++ b/src/bypasses/adtival.js
@@ -9,6 +9,82 @@ export default class Adtival extends BypassDefinition {
   execute() {
     console.log('Adtival found!');
 
+    const executor = async () => {
+      const El = window.livewire.components.components()[0];
+
+      const payload = {
+        fingerprint: El.fingerprint,
+        serverMemo: El.serverMemo,
+        updates: [
+          {
+            payload: {
+              event: 'getData',
+              id: 'whathappen',
+              params: [],
+            },
+            type: 'fireEvent',
+          },
+        ],
+      };
+
+      const response = await fetch(
+        location.origin + '/livewire/message/pages.show',
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Livewire': 'true',
+            'X-CSRF-TOKEN': window.livewire_token,
+          },
+          method: 'POST',
+          body: JSON.stringify(payload),
+        }
+      );
+
+      const json = await response.json();
+
+      // ensure URL
+      const url = new URL(json.effects.emits[0].params[0]);
+
+      this.helpers.safelyAssign(url.href);
+      // this.helpers.unsafelyNavigate(url.href, location.href)
+    };
+
+    // special case for sekilastekno. modbaca(?)
+    if (RegExp(/(modebaca|sekilastekno)\.com/).exec(location.host)) {
+      this.helpers.ifElement("form[method='post']", (a) => {
+        console.log('addRecord...');
+
+        const input = document.createElement('input');
+        input.value = window.livewire_token;
+        input.name = '_token';
+        input.hidden = true;
+        a.appendChild(input);
+        a.submit();
+      });
+
+      // ...same step as miuiku and vebma
+      this.helpers.ifElement('button[x-text]', async () => {
+        console.log('getLink..');
+        executor();
+      });
+
+      return;
+    }
+
+    // adtival getLink on miuiku
+    this.helpers.ifElement("div[class='max-w-5xl mx-auto']", async () => {
+      console.log('Executing..');
+      executor();
+    });
+
+    // adtival b64UrlLastPage
+    this.helpers.ifElement("button[id='copyVideoURL']", () => {
+      const shortID = new URLSearchParams(window.location.search).get(
+        'shortid'
+      );
+
+      this.helpers.safelyAssign(atob(shortID));
+    });
   }
 }
 

--- a/src/bypasses/adtival.js
+++ b/src/bypasses/adtival.js
@@ -1,0 +1,18 @@
+import BypassDefinition from './BypassDefinition.js';
+
+export default class Adtival extends BypassDefinition {
+  constructor() {
+    super();
+    this.ensure_dom = true;
+  }
+
+  execute() {
+    console.log('Adtival found!');
+
+  }
+}
+
+export const matches = [
+  /movienear\.me|lewat\.club|tautan\.pro|(droidtamvan|gubukbisnis|onlinecorp)\.me|(liveshootv|modebaca|haipedia|sekilastekno|miuiku|vebma)\.com|shrink\.world|link\.mymastah\.xyz|(sportif|cararoot)\.id|healthinsider\.online/,
+  'www.adtival.network',
+];


### PR DESCRIPTION
Fix(es): 
<!-- A brief description of what you did -->
Add adtival.js for Adtival.network related shortlink domain. should fixed miuiku.com, sekilastekno.com, also add new bypass for vebma.com
<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code;
- [ ] Tested on Chromium (Includes Opera, Brave, Vivaldi, Edge, etc);
- [x] Tested on Firefox.
