### PR TITLE
added bypass for enlacito.com

### DIFF
--- a/src/bypasses/enlacito.js
+++ b/src/bypasses/enlacito.js
@@ -1,0 +1,16 @@
+import BypassDefinition from './BypassDefinition.js'
+
+export default class Enlacito extends BypassDefinition {
+    constructor() {
+        super()
+        this.ensure_dom = true
+    }
+
+    execute() {
+        this.helpers.safelyNavigate(window.DYykkzwP)
+    }
+}
+
+// This is a link protecor that I've seen in many domains, so this script probably works in many of them
+// If you find another domain that uses this script, please add it to the array below
+export const matches = ['enlacito.com']


### PR DESCRIPTION
Fix(es): 
<!-- A brief description of what you did -->
I've added a new bypass (in MV3 format) for the link protector "enlacito.com"
This is a domain for a shortener that I've seen in more domains, but I can't recall any of them, so I've made it for this one.

The other ones I remember seeing had a similar interface, with the text changed, so I guess that this script may work for those too, and it's just a matter of adding it to the `matches` array.
This is the UI of the site, for reference, and if someone knows any other domain for this shortener, I'd be glad to add it to the script if they're unable to:
![enlacito com_](https://github.com/FastForwardTeam/FastForward/assets/51211491/e54e1be1-1fd4-4c89-852f-7fa891d2de58)

<!--Add an x to mark as done-->
- [*] I made sure there are no unnecessary changes in the code;
- [*] Tested on Chromium (Includes Opera, Brave, Vivaldi, Edge, etc);
- [*] Tested on Firefox.
