### PR TITLE
Substitution in spanish now works (didn't before)

### DIFF
--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -33,7 +33,7 @@
 		"message": "Preguntas frecuentes"
 	},
 	"bypassCounter": {
-		"message": "FastForward ya ha evadido % sitios para ti."
+		"message": "FastForward ya ha evadido $1 sitios para ti."
 	},
 	"support": {
 		"message": "Ayuda a FastForward"
@@ -105,19 +105,19 @@
 		"message": "Ya casi estás en tu destino."
 	},
 	"beforeNavigateDestination": {
-		"message": "Tu dirección de destino es %"
+		"message": "Tu dirección de destino es $1"
 	},
 	"beforeNavigateUnsafe": {
 		"message": "Sin embargo, si navegas ahora, FastForward será detectado."
 	},
 	"beforeNavigateUnsafeTimer": {
-		"message": "No podrás ser detectado en % segundos."
+		"message": "No podrás ser detectado en $1 segundos."
 	},
 	"beforeNavigateUnsafeTimerSingular": {
 		"message": "No podrás ser detectado en 1 segundo."
 	},
 	"beforeNavigateTimer": {
-		"message": "Serás redirigido automáticamente en % segundos."
+		"message": "Serás redirigido automáticamente en $1 segundos."
 	},
 	"beforeNavigateTimerSingular": {
 		"message": "Serás redirigido automáticamente en 1 segundo."
@@ -126,7 +126,7 @@
 		"message": "¿Quieres ser redirigido al instante, o en x segundos?"
 	},
 	"beforeNavigateInstant": {
-		"message": "Estás siendo redirigido a %"
+		"message": "Estás siendo redirigido a $1"
 	},
 	"infoLinkvertise": {
 		"message": "No se nos permite evadir este sitio web, pero hemos negociado la eliminación de sus pasos más molestos."
@@ -147,16 +147,16 @@
 		"message": "¡Puede que no tengas que esperar!"
 	},
 	"crowdBypassedInfo": {
-		"message": "Otros usuarios de FastForward ya han esperado por ti y han informado que esto lleva a %"
+		"message": "Otros usuarios de FastForward ya han esperado por ti y han informado que esto lleva a $1"
 	},
 	"crowdBypassedTimer": {
-		"message": "Esto se abrirá en una pestaña nueva en % segundos."
+		"message": "Esto se abrirá en una pestaña nueva en $1 segundos."
 	},
 	"crowdBypassedTimerSingular": {
 		"message": "Esto se abrirá en una pestaña nueva en 1 segundo."
 	},
 	"crowdCloseTimer": {
-		"message": "Esta pestaña se cerrará en % segundos."
+		"message": "Esta pestaña se cerrará en $1 segundos."
 	},
 	"crowdCloseTimerSingular": {
 		"message": "Esta pestaña se cerrará en 1 segundo."


### PR DESCRIPTION
Fix(es): 
<!-- A brief description of what you did -->
Some substitutions didn't work in Spanish. I suspect they might not work in more languages, I made a quick python script that suggests that more than 500 entries would need updating. I think that it's possible to do this automatically, by replacing the "%" sign with a "$1 in every message which key doesn't contain "option" (as the options page ones need the "%" for input places and such), but I don't really want to make a possibly breaking change to so many languages. I'll upload the script I made to a gist for if someone want's to take a look at it.

<!--Add an x to mark as done-->
- [*] I made sure there are no unnecessary changes in the code;
- [*] Tested on Chromium (Includes Opera, Brave, Vivaldi, Edge, etc);
- [*] Tested on Firefox.
