### PR TITLE
Fix linkvertise r param bypass

### DIFF
--- a/src/bypasses/linkvertise.js
+++ b/src/bypasses/linkvertise.js
@@ -7,7 +7,7 @@ export default class Linkvertise extends BypassDefinition {
   }
 
   execute () {
-    if (window.location.href.toString().includes('?r=')) {
+    if (/[\?&]r=/.test(window.location.href.toString())) {
       const urlParams = new URLSearchParams(window.location.search)
       const r = urlParams.get('r')
       this.helpers.safelyNavigate(atob(decodeURIComponent(r)))


### PR DESCRIPTION
Fix(es): 
This PR changes the "?r=" url param check to a regex that also accepts &, because sometimes the linkvertise links end up as `?link_origin=adfly&r=...` which breaks the current bypass.

- [x] I made sure there are no unnecessary changes in the code;
- [x] Tested on Chromium (Includes Opera, Brave, Vivaldi, Edge, etc);
- [x] Tested on Firefox.
