### PR TITLE
Fix Lootlink bypass

### DIFF
--- a/src/bypasses/lootlink.js
+++ b/src/bypasses/lootlink.js
@@ -7,7 +7,7 @@ export default class LootLink extends BypassDefinition {
     }
 
     execute() {
-        if (/[\?&]r=/.test(window.location.href.toString())) {
+        if (/[?&]r=/.test(window.location.href.toString())) {
             const urlParams = new URLSearchParams(window.location.search)
             const r = urlParams.get('r')
             const finalURL = decodeURIComponent(escape(atob(r)));

--- a/src/bypasses/lootlink.js
+++ b/src/bypasses/lootlink.js
@@ -7,19 +7,13 @@ export default class LootLink extends BypassDefinition {
     }
 
     execute() {
-        // the bypass to this is reminiscent to decoding cloudflare's email protection but with the exception that this uses the first 5 bytes as the key and cloudflare uses the first 1
-        let final = ""
-        let combinationLink = atob(p.PUBLISHER_LINK)
-        let key = combinationLink.substring(0, 5)
-        let enc_link = combinationLink.substring(5)
-        for (let i = 0; i < enc_link.length; i++) {
-            let enc_char = enc_link.charCodeAt(i)
-            let keyAtOffset = key.charCodeAt(i % key.length)
-            let charcode = enc_char ^ keyAtOffset
-            final += String.fromCharCode(charcode)
+        if (/[\?&]r=/.test(window.location.href.toString())) {
+            const urlParams = new URLSearchParams(window.location.search)
+            const r = urlParams.get('r')
+            const finalURL = decodeURIComponent(escape(atob(r)));
+            this.helpers.safelyNavigate(finalURL)
         }
-        this.helpers.safelyNavigate(final)
     }
 }
 
-export const matches = ['lootlinks.co']
+export const matches = ['lootlinks.co', 'loot-links.com', 'loot-link.com']

--- a/src/js/content_script.js
+++ b/src/js/content_script.js
@@ -14,6 +14,7 @@ function getExtBaseURL() {
 async function injectScript() {
   let options = await getOptions();
   if (
+    options &&
     options.whitelist &&
     matchDomains(window.location.hostname, options.whitelist)
   ) {


### PR DESCRIPTION
Fix(es): 
- Solve #1329 issue
- Error not finding whitelist value in undefined when whitelist is empty

<!--Add an x to mark as done-->
- [x] I made sure there are no unnecessary changes in the code;
- [x] Tested on Chromium (Includes Opera, Brave, Vivaldi, Edge, etc);
- [ ] Tested on Firefox.
